### PR TITLE
인증 로직 db 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        queryDslVersion = "5.0.0"
+        queryDslVersion = "4.4.0"
     }
 }
 

--- a/src/main/java/com/ttbkk/api/auth/AuthDto.java
+++ b/src/main/java/com/ttbkk/api/auth/AuthDto.java
@@ -8,7 +8,6 @@ import lombok.ToString;
 import javax.validation.constraints.NotEmpty;
 import java.math.BigInteger;
 import java.util.Map;
-import java.util.Optional;
 
 public class AuthDto {
     @Getter

--- a/src/main/java/com/ttbkk/api/auth/AuthDto.java
+++ b/src/main/java/com/ttbkk/api/auth/AuthDto.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 import javax.validation.constraints.NotEmpty;
 import java.math.BigInteger;
 import java.util.Map;
+import java.util.Optional;
 
 public class AuthDto {
     @Getter
@@ -40,6 +41,7 @@ public class AuthDto {
     public static class JwtGoogle {
         /**
          * JwtGoogle 인스턴스 생성자.
+         * 필수값이면서 유저를 식별 가능한 값은 sub이므로, 해당 값을 우리 서버의 유저 식별자로 사용한다.
          * @param hashmap 파싱 된 Google JWT.
          */
         public JwtGoogle(Map<String, Object> hashmap) {
@@ -58,18 +60,18 @@ public class AuthDto {
             this.jti = (String) hashmap.get("jti");
         }
 
-        private String iss;
-        private BigInteger nbf;
-        private String aud;
-        private String sub;
+        private String iss; // Issuer (who created and signed this token)
+        private BigInteger nbf; // Not valid before (seconds since Unix epoch)
+        private String aud; // Audience (who or what the token is intended for)
+        private String sub; // Subject (whom the token refers to)
         private String email;
         private boolean emailVerified;
-        private String azp;
+        private String azp; // Authorized party (the party to which this token was issued)
         private String name;
         private String picture;
         private String givenName;
-        private BigInteger iat;
-        private BigInteger exp;
-        private String jti;
+        private BigInteger iat; // Issued at (seconds since Unix epoch)
+        private BigInteger exp; // Expiration time (seconds since Unix epoch)
+        private String jti; // JWT ID (unique identifier for this token)
     }
 }

--- a/src/main/java/com/ttbkk/api/auth/AuthService.java
+++ b/src/main/java/com/ttbkk/api/auth/AuthService.java
@@ -38,15 +38,14 @@ public class AuthService {
         Map<String, Object> jwtHashMap = jwtService.parse(authProviderToken);
         AuthDto.JwtGoogle googleJwt = new AuthDto.JwtGoogle(jwtHashMap);
         User user = userService
-            .findBySocialId(googleJwt.getEmail())
+            .findBySocialId(googleJwt.getSub())
             .orElseGet(
                 () -> userService.create(
-                    googleJwt.getEmail(),
-                    googleJwt.getName(),
+                    googleJwt.getSub(),
                     "GOOGLE"
                 )
             );
-        return jwtService.encode(user, googleJwt.getPicture());
+        return jwtService.encode(user);
     }
 
     /**
@@ -60,11 +59,9 @@ public class AuthService {
     public User myInfo(String accessToken) throws ParseException {
         Map<String, Object> jwtHashMap = jwtService.parse(accessToken);
         String socialId = (String) jwtHashMap.get("socialId");
-        String nickname = (String) jwtHashMap.get("nickname");
 
         return User.builder()
             .socialId(socialId)
-            .nickname(nickname)
             .build();
     }
 }

--- a/src/main/java/com/ttbkk/api/auth/AuthService.java
+++ b/src/main/java/com/ttbkk/api/auth/AuthService.java
@@ -29,6 +29,7 @@ public class AuthService {
     /**
      * 로그인 함수.
      * 자세한 내용은 AuthController.signIn 참고.
+     *
      * @param authProviderToken google 등으로부터 받은 JWT
      * @return String 우리 서버에서 발급하는 JWT
      * @throws ParseException 파싱 예외처리
@@ -38,8 +39,8 @@ public class AuthService {
         AuthDto.JwtGoogle googleJwt = new AuthDto.JwtGoogle(jwtHashMap);
         User user = userService
             .findBySocialId(googleJwt.getEmail())
-            .orElse(
-                userService.create(
+            .orElseGet(
+                () -> userService.create(
                     googleJwt.getEmail(),
                     googleJwt.getName(),
                     "GOOGLE"
@@ -51,6 +52,7 @@ public class AuthService {
     /**
      * 내 정보 조회.
      * 자세한 내용은 AuthController.myInfo 참고.
+     *
      * @param accessToken 우리 서버에서 발급받은 JWT
      * @return User 토큰으로부터 파싱/조회 된 유저
      * @throws ParseException 파싱 예외처리

--- a/src/main/java/com/ttbkk/api/auth/JWTService.java
+++ b/src/main/java/com/ttbkk/api/auth/JWTService.java
@@ -22,10 +22,9 @@ public class JWTService {
     /**
      * 유저 데이터를 JWT로 암호화 하는 함수.
      * @param user User 객체
-     * @param imgUrl 로그인 시 받을 수 있는 로그인 제공사에 저장된 프로필 이미지
      * @return String 생성된 JWT String
      */
-    public String encode(User user, String imgUrl) {
+    public String encode(User user) {
         Date now = new Date();
         String secretKey = "secret"; // 토큰 변경에 필요한 secret key
         int expireSeconds = 60 * 60; // 토큰의 만료 기간
@@ -34,8 +33,6 @@ public class JWTService {
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + Duration.ofMinutes(expireSeconds).toMillis()))
                 .claim("socialId", user.getSocialId())
-                .claim("nickname", user.getNickname())
-                .claim("imgUrl", imgUrl)
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }

--- a/src/main/java/com/ttbkk/api/auth/test/google-login.html
+++ b/src/main/java/com/ttbkk/api/auth/test/google-login.html
@@ -17,16 +17,12 @@
 </div>
 <div>
     <li>
-        <span>이메일</span>
-        <input id="email"></input>
+        <span>socialId</span>
+        <input id="socialId"></input>
     </li>
     <li>
-        <span>이름</span>
-        <input id="name"></input>
-    </li>
-    <li>
-        <span>프로필</span>
-        <img id="picture"/>
+        <span>nickname</span>
+        <input id="nickname"></input>
     </li>
 </div>
 <script>
@@ -34,8 +30,8 @@
         const baseUrl = "http://localhost:8080";
         console.log("before fetch")
         axios.post(
-            `${baseUrl}/api/v1/auth/signin/google`,
-            {accessToken: data.credential},
+            `${baseUrl}/auth/signin/google`,
+            {authProviderToken: data.credential},
         )
             .then((res) => {
                 console.log(res);
@@ -44,7 +40,7 @@
             })
             .then((accessToken) => {
                 return axios.get(
-                    `${baseUrl}/api/v1/auth/myinfo`,
+                    `${baseUrl}/auth/myinfo`,
                     {
                         headers: {
                             Authorization: `Bearer ${accessToken}`,
@@ -54,17 +50,12 @@
             })
             .then((res) => {
                 console.log(res);
-                const {picture, name, email} = res.data;
-                const pictureElement = document.getElementById("picture");
-                pictureElement.setAttribute("src", picture);
-                pictureElement.setAttribute("width", "64px");
-                pictureElement.setAttribute("height", "64px");
+                const {nickname, socialId} = res.data;
+                const nameElement = document.getElementById("nickname");
+                nameElement.setAttribute("value", nickname);
 
-                const nameElement = document.getElementById("name");
-                nameElement.setAttribute("value", name);
-
-                const emailElement = document.getElementById("email");
-                emailElement.setAttribute("value", email);
+                const emailElement = document.getElementById("socialId");
+                emailElement.setAttribute("value", socialId);
             })
     }
 </script>

--- a/src/main/java/com/ttbkk/api/auth/test/google-login.html
+++ b/src/main/java/com/ttbkk/api/auth/test/google-login.html
@@ -20,10 +20,6 @@
         <span>socialId</span>
         <input id="socialId"></input>
     </li>
-    <li>
-        <span>nickname</span>
-        <input id="nickname"></input>
-    </li>
 </div>
 <script>
     function callback(data) {
@@ -50,9 +46,7 @@
             })
             .then((res) => {
                 console.log(res);
-                const {nickname, socialId} = res.data;
-                const nameElement = document.getElementById("nickname");
-                nameElement.setAttribute("value", nickname);
+                const {socialId} = res.data;
 
                 const emailElement = document.getElementById("socialId");
                 emailElement.setAttribute("value", socialId);

--- a/src/main/java/com/ttbkk/api/user/User.java
+++ b/src/main/java/com/ttbkk/api/user/User.java
@@ -26,10 +26,6 @@ public class User extends BaseTimeEntity {
     private String id;
 
     @NotNull
-    @Column(columnDefinition = "VARCHAR(50)")
-    private String nickname;
-
-    @NotNull
     @Column(name = "social_id", columnDefinition = "VARCHAR(50)")
     private String socialId;
 
@@ -51,14 +47,12 @@ public class User extends BaseTimeEntity {
 
     /**
      * User 생성자.
-     * @param nickname 닉네임
      * @param socialId 로그인 서비스에서 사용중인 식별자. 예) email
      * @param socialType 로그인 서비스 이름
      */
     @Builder
-    public User(String nickname, String socialId, String socialType) {
+    public User(String socialId, String socialType) {
         this.id = UUID.randomUUID().toString().replace("-", "");
-        this.nickname = nickname;
         this.socialId = socialId;
         this.socialType = socialType;
     }

--- a/src/main/java/com/ttbkk/api/user/UserService.java
+++ b/src/main/java/com/ttbkk/api/user/UserService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.util.Optional;
@@ -12,6 +13,7 @@ import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 
     /**
@@ -22,12 +24,13 @@ public class UserService {
 
     /**
      * 입력된 socialId를 가지는 유저가 존재하는지 조회합니다.
+     *
      * @param socialId 구글의 경우 email 에 해당됩니다.
      * @return Optional<User> 유저를 찾지 못한 경우 null 이 반환됩니다.
      */
     public Optional<User> findBySocialId(String socialId) {
+        QUser qUser = QUser.user;
         JPAQuery<User> query = new JPAQuery<>(this.entityManager);
-        QUser qUser = new QUser("user");
         return Optional.ofNullable(
             query
                 .from(qUser)
@@ -40,8 +43,9 @@ public class UserService {
 
     /**
      * 유저를 생성합니다.
-     * @param socialId 구글 로그인 시 email 에 해당됩니다.
-     * @param nickname 구글 로그인 시 name 에 해당됩니다.
+     *
+     * @param socialId   구글 로그인 시 email 에 해당됩니다.
+     * @param nickname   구글 로그인 시 name 에 해당됩니다.
      * @param socialType 구글 로그인 시 GOOGLE 에 해당됩니다.
      * @return User 생성된 유저가 반환됩니다.
      */

--- a/src/main/java/com/ttbkk/api/user/UserService.java
+++ b/src/main/java/com/ttbkk/api/user/UserService.java
@@ -10,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import java.util.Optional;
 
+import static com.ttbkk.api.user.QUser.user;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -29,13 +31,12 @@ public class UserService {
      * @return Optional<User> 유저를 찾지 못한 경우 null 이 반환됩니다.
      */
     public Optional<User> findBySocialId(String socialId) {
-        QUser qUser = QUser.user;
         JPAQuery<User> query = new JPAQuery<>(this.entityManager);
         return Optional.ofNullable(
             query
-                .from(qUser)
+                .from(user)
                 .where(
-                    qUser.socialId.eq(socialId)
+                    user.socialId.eq(socialId)
                 )
                 .fetchOne()
         );

--- a/src/main/java/com/ttbkk/api/user/UserService.java
+++ b/src/main/java/com/ttbkk/api/user/UserService.java
@@ -46,14 +46,12 @@ public class UserService {
      * 유저를 생성합니다.
      *
      * @param socialId   구글 로그인 시 email 에 해당됩니다.
-     * @param nickname   구글 로그인 시 name 에 해당됩니다.
      * @param socialType 구글 로그인 시 GOOGLE 에 해당됩니다.
      * @return User 생성된 유저가 반환됩니다.
      */
-    public User create(String socialId, String nickname, String socialType) {
+    public User create(String socialId, String socialType) {
         User user = User.builder()
             .socialId(socialId)
-            .nickname(nickname)
             .socialType(socialType)
             .build();
         this.entityManager.persist(user);

--- a/src/main/resources/db/migration/V2__remove_nickname.sql
+++ b/src/main/resources/db/migration/V2__remove_nickname.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user DROP COLUMN nickname;

--- a/src/test/java/com/ttbkk/api/user/UserTest.java
+++ b/src/test/java/com/ttbkk/api/user/UserTest.java
@@ -25,7 +25,6 @@ class UserTest {
     @Test
     void userEntityVerify() {
         User user = User.builder()
-                .nickname("정지원")
                 .socialId("test id")
                 .socialType("test type")
                 .build();


### PR DESCRIPTION
- com.querydsl:querydsl-core가 4.4.0으로 설치되어 특정 필드를 찾지 못하는 이슈가 있어서 5.x.x 버전이 안정화 되기 전까지는 일단 4.4.0을 사용하고자 다운그레이드를 했습니다.
- querydsl을 통해 유저를 조회합니다.
- jpa를 이용해 유저를 db에 생성합니다.